### PR TITLE
added config option to hide sunrise/sunset in Current Weather module

### DIFF
--- a/modules/currentweather.md
+++ b/modules/currentweather.md
@@ -47,6 +47,7 @@ The following properties can be configured:
 | `showWindDirection`          | Show the wind direction next to the wind speed. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `showWindDirectionAsArrow`   | Show the wind direction as an arrow instead of abbreviation <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showHumidity`               | Show the current humidity <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `showSun`                    | Show sunset and sunrise time <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `showIndoorTemperature`      | If you have another module that emits the INDOOR_TEMPERATURE notification, the indoor temperature will be displayed <br> **Default value:** `false`
 | `onlyTemp`                   | Show only current Temperature and weather icon without windspeed, sunset, sunrise time and feels like. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showFeelsLike`              | Shows the Feels like temperature weather. <br><br> **Possible values:**`true` or `false`<br>**Default value:** `true`


### PR DESCRIPTION
Adds documentation of configuration option to hide sunrise/sunset in the default Current Weather module.

Configuration option is `showSun` to match the addition to the default Weather module.

Appropriate [pull request](https://github.com/MichMich/MagicMirror/pull/2059) also submitted to [MagicMirror](https://github.com/MichMich/MagicMirror).