### PR TITLE
Add config guide for Met Office DataHub weather provider

### DIFF
--- a/modules/weather.md
+++ b/modules/weather.md
@@ -8,7 +8,7 @@ The module is in a very early stage, and needs a lot of work. It's API isn't set
 
 ## Example
 
-![Current Weather Screenshot](current.png) ![Weather Forecast Screenshot](forecast.png)
+![Current Weather Screenshot](screenshots/current.png) ![Weather Forecast Screenshot](screenshots/forecast.png)
 
 ## Usage
 
@@ -124,7 +124,7 @@ The following properties can be configured:
 | `apiSecret`                  | Your API secret (see above).
 | `lat`                        | The latitude coordinate for the desired location. <br><br> **Possible value:** `50.7271915`
 | `lon`                        | The longitude coordinate for the descired location. <br><br> **Possible value:** `-3.4776089`
-| `windUnits`                  | Set the units for wind speed. If not specified, uses the `units` value from `config.js` <br><br> **Possible values:** `mps` = metres per second, `kmh` or `metric` = kilometres per hour, `mph` or `imperial` = miles per hour
+| `windUnits`                  | Set the units for wind speed. If not specified, uses the `units` value from `config.js`. This option is useful for those in the UK, for example, where we use metric units but have wind speed in mph. <br><br> **Possible values:** `mps` = metres per second, `kmh` or `metric` = kilometres per hour, `mph` or `imperial` = miles per hour
 
 ## API Provider Development
 

--- a/modules/weather.md
+++ b/modules/weather.md
@@ -115,6 +115,17 @@ The following properties can be configured:
 | `locationID`	               | The UKMO API location code. <br><br> **Possible values:** `322942` <br>  This value is **REQUIRED**
 | `apiKey`                     | The [UK Met Office](https://www.metoffice.gov.uk/datapoint/getting-started) API key, which can be obtained by creating an UKMO Datapoint account. <br><br>  This value is **REQUIRED**
 
+### UK Met Office (DataHub) options
+
+| Option                       | Description
+| ---------------------------- | -----------
+| `apiBase`                    | The UKMO DataHub base URL.<br><br> **Possible value:**  `'https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0/forecasts/point/'` <br> This value is **REQUIRED**
+| `apiKey`                     | Your API key. See the [Getting Started](https://metoffice.apiconnect.ibmcloud.com/metoffice/production/start) guide on the Met Office website for creating a new account. <br> This value is **REQUIRED**
+| `apiSecret`                  | Your API secret (see above).
+| `lat`                        | The latitude coordinate for the desired location. <br><br> **Possible value:** `50.7271915`
+| `lon`                        | The longitude coordinate for the descired location. <br><br> **Possible value:** `-3.4776089`
+| `windUnits`                  | Set the units for wind speed. If not specified, uses the `units` value from `config.js` <br><br> **Possible values:** `mps` = metres per second, `kmh` or `metric` = kilometres per hour, `mph` or `imperial` = miles per hour
+
 ## API Provider Development
 
 If you want to add another API provider checkout the [Guide](providers).

--- a/modules/weather.md
+++ b/modules/weather.md
@@ -121,9 +121,9 @@ The following properties can be configured:
 | ---------------------------- | -----------
 | `apiBase`                    | The UKMO DataHub base URL.<br><br> **Possible value:**  `'https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0/forecasts/point/'` <br> This value is **REQUIRED**
 | `apiKey`                     | Your API key. See the [Getting Started](https://metoffice.apiconnect.ibmcloud.com/metoffice/production/start) guide on the Met Office website for creating a new account. <br> This value is **REQUIRED**
-| `apiSecret`                  | Your API secret (see above).
-| `lat`                        | The latitude coordinate for the desired location. <br><br> **Possible value:** `50.7271915`
-| `lon`                        | The longitude coordinate for the descired location. <br><br> **Possible value:** `-3.4776089`
+| `apiSecret`                  | Your API secret (see above). <br> This value is **REQUIRED**
+| `lat`                        | The latitude coordinate for the desired location. <br><br> **Possible value:** `50.7271915` <br> This value is **REQUIRED**
+| `lon`                        | The longitude coordinate for the descired location. <br><br> **Possible value:** `-3.4776089` <br> This value is **REQUIRED**
 | `windUnits`                  | Set the units for wind speed. If not specified, uses the `units` value from `config.js`. This option is useful for those in the UK, for example, where we use metric units but have wind speed in mph. <br><br> **Possible values:** `mps` = metres per second, `kmh` or `metric` = kilometres per hour, `mph` or `imperial` = miles per hour
 
 ## API Provider Development


### PR DESCRIPTION
After just receiving the notification about the new release, it reminded me to update the docs for the new provider.

I also fixed the screenshots as I noticed their paths were set incorrectly.