### PR TITLE
solved the bugs for lacking of electron

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -13,9 +13,10 @@ Therefore the only officially supported way of installation is by using a [manua
 3. Enter the repository: `cd MagicMirror/`
 4. Install the application: `npm install`
 5. Make a copy of the config sample file: `cp config/config.js.sample config/config.js`
-6. Start the application: `npm run start` \
+6. Install electron: `npm install electron --save-dev`
+7. Start the application: `npm run start` \
    For **Server Only** use: `npm run server` .
-7. See next section for common installation issues.
+8. See next section for common installation issues.
 
 ::: warning NOTE
 The installation step for `npm install` will take a very long time, often with little or no terminal response! For the RPi3 this is **~10** minutes and for the Rpi2 **~25** minutes. Do not interrupt or you risk getting a :broken_heart: by Raspberry Jam.


### PR DESCRIPTION
I do as the installation guide says and I meet some bugs as follows.
```
> magicmirror@2.15.0 start /home/pi/MagicMirror
> DISPLAY="${DISPLAY:=:0}" ./node_modules/.bin/electron js/electron.js

sh: 1: ./node_modules/.bin/electron: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! magicmirror@2.15.0 start: `DISPLAY="${DISPLAY:=:0}" ./node_modules/.bin/electron js/electron.js`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the magicmirror@2.15.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pi/.npm/_logs/2021-04-08T03_50_15_743Z-debug.log
```
I used the pi3B+, and the newest raspberryos in March.
And I solved the problem by installing electron, so I added the step into  installation guide.