### PR TITLE
Add some pages from wiki to the docs

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -16,6 +16,7 @@ module.exports = {
           'getting-started/requirements',
           'getting-started/installation',
           'getting-started/configuration',
+          'getting-started/autostart',
           'getting-started/upgrade-guide',
           'getting-started/license',
           'getting-started/contributing',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -61,6 +61,7 @@ module.exports = {
           'development/logger.md',
           'development/notifications.md',
           'development/weather-provider.md',
+          'development/documentation.md',
         ]
       }
     ],

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -58,6 +58,7 @@ module.exports = {
           'development/node-helper.md',
           'development/helper-methods.md',
           'development/logger.md',
+          'development/notifications.md',
           'development/weather-provider.md',
         ]
       }

--- a/README.md
+++ b/README.md
@@ -3,21 +3,19 @@ title: Introduction
 ---
 ![MagicMirror²: The open source modular smart mirror platform. ](header.png)
 
-<p align="center">
+<p style="text-align: center">
 	<a href="https://david-dm.org/MichMich/MagicMirror"><img src="https://david-dm.org/MichMich/MagicMirror.svg" alt="Dependency Status"></a>
-	<a href="https://david-dm.org/MichMich/MagicMirror#info=devDependencies"><img src="https://david-dm.org/MichMich/MagicMirror/dev-status.svg" alt="devDependency Status"></a>
-	<a href="https://bestpractices.coreinfrastructure.org/projects/347"><img src="https://bestpractices.coreinfrastructure.org/projects/347/badge"></a><br>
-	<a href="http://choosealicense.com/licenses/mit"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
-	<a href="https://travis-ci.com/MichMich/MagicMirror"><img src="https://travis-ci.com/MichMich/MagicMirror.svg" alt="Travis"></a>
-	<a href="https://snyk.io/test/github/MichMich/MagicMirror"><img src="https://snyk.io/test/github/MichMich/MagicMirror/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/MichMich/MagicMirror" style="max-width:100%;"></a>
+	<a href="https://david-dm.org/MichMich/MagicMirror?type=dev"><img src="https://david-dm.org/MichMich/MagicMirror/dev-status.svg" alt="devDependency Status"></a>
+	<a href="https://bestpractices.coreinfrastructure.org/projects/347"><img src="https://bestpractices.coreinfrastructure.org/projects/347/badge" alt="CLI Best Practices"></a>
+	<a href="https://codecov.io/gh/MichMich/MagicMirror"><img src="https://codecov.io/gh/MichMich/MagicMirror/branch/master/graph/badge.svg?token=LEG1KitZR6" alt="CodeCov Status"/></a>
+	<a href="https://choosealicense.com/licenses/mit"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+	<a href="https://github.com/MichMich/MagicMirror/actions?query=workflow%3A%22Automated+Tests%22"><img src="https://github.com/MichMich/MagicMirror/workflows/Automated%20Tests/badge.svg" alt="Tests"></a>
 </p>
 
 [**MagicMirror²**](https://magicmirror.builders/) is an open source modular smart mirror platform. With a growing list of installable modules, the **MagicMirror²** allows you to convert your hallway or bathroom mirror into your personal assistant. **MagicMirror²** is built by the creator of [the original MagicMirror](http://michaelteeuw.nl/tagged/magicmirror) with the incredible help of a [growing community of contributors](https://github.com/MichMich/MagicMirror/graphs/contributors).
 
-MagicMirror² focuses on a modular plugin system and uses [Electron](http://electron.atom.io/) as an application wrapper. So no more web server or browser installs necessary!
+MagicMirror² focuses on a modular plugin system and uses [Electron](https://www.electronjs.org/) as an application wrapper. So no more web server or browser installs necessary!
 
-
-<p align="center">
-<br>
+<p style="text-align: center">
 	<a href="https://forum.magicmirror.builders/topic/728/magicmirror-is-voted-number-1-in-the-magpi-top-50"><img src="https://magicmirror.builders/img/magpi-best-watermark-custom.png" width="150" alt="MagPi Top 50"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ title: Introduction
 	<a href="https://github.com/MichMich/MagicMirror/actions?query=workflow%3A%22Automated+Tests%22"><img src="https://github.com/MichMich/MagicMirror/workflows/Automated%20Tests/badge.svg" alt="Tests"></a>
 </p>
 
-[**MagicMirror²**](https://magicmirror.builders/) is an open source modular smart mirror platform. With a growing list of installable modules, the **MagicMirror²** allows you to convert your hallway or bathroom mirror into your personal assistant. **MagicMirror²** is built by the creator of [the original MagicMirror](http://michaelteeuw.nl/tagged/magicmirror) with the incredible help of a [growing community of contributors](https://github.com/MichMich/MagicMirror/graphs/contributors).
+[**MagicMirror²**](https://magicmirror.builders/) is an open source modular smart mirror platform. With a growing list of installable modules, the **MagicMirror²** allows you to convert your hallway or bathroom mirror into your personal assistant. **MagicMirror²** is built by the creator of [the original MagicMirror](https://michaelteeuw.nl/tagged/magicmirror) with the incredible help of a [growing community of contributors](https://github.com/MichMich/MagicMirror/graphs/contributors).
 
 MagicMirror² focuses on a modular plugin system and uses [Electron](https://www.electronjs.org/) as an application wrapper. So no more web server or browser installs necessary!
 

--- a/development/documentation.md
+++ b/development/documentation.md
@@ -1,0 +1,44 @@
+# How to write good documentation
+
+MagicMirror is meant to be accessible to anyone with any skill level. But to help promote building technical skills 
+and educate in these technologies, it requires a little bit more effort from developers to make their amazing projects 
+more easily obtainable by ordinary people. 
+
+Most novices coming to MM are overwhelmed by the amount of information and perhaps even the technology itself. To 
+overcome this obstacle, they need a lot of help in getting things going. As with anything we learn in life, we take it
+one step at the time. 
+
+Here is a guideline for writing a non-technical installation documentation to help people use your creation.
+
+It's in no way meant to be exhaustive, but it will try to make sure to relieve your github issues from excessive novice
+questions and in addition makes it much easier to post good and useful answers. 
+
+### The most important points in writing software installation documentation:
+
+* **Don't assume any previous knowledge!** 
+  This is by far, the number one documentation issue and failure!
+* **Does the software depend on any other, previously installed software?**  
+    * If so make sure to either re-iterate the steps or link to equivalently good installation instructions.
+    * Specify exactly what it depends on, and where to find it.
+* **Are the steps following a logical order of operations?**  
+  You'll be surprised!
+* **Is the information you give correct?**  
+  Don't guess how things work!
+* **Are all the steps up-to-date with current master repository code and functionality?**  
+  This is the hardest to keep up, since most projects in github are constantly under development.
+* **Are your screenshots up-to-date with how the UI actually looks?**  
+  You have screenshots, right!? A million of your words could never replace them.
+* **Have you started from scratch and followed your own installation instructions?**  
+  This step is what fails 99.9% of all documentation. Unfortunately developers are incredibly lazy in this regard, 
+  since they think it's a waste of time. I'm sure NASA has something to teach you about this.
+* **Can anyone complete the steps successfully?**  
+  Can your 9 year old baby sister or grandma follow the steps without asking for help?
+* **Can anyone raise a question in the github issues?**  
+  * Are you going to answer respectfully, short and concise and point the user to where to find the information, and 
+  take into consideration that perhaps something is not clear from your documentation and needs more attention. (Perhaps
+  the UI, a dependency or link has changed?) 
+  * Or are you going to be a cocky ass and give degrading comments?
+
+---
+
+### And always remember: IF YOU WRITE IT GOOD, THEY WILL COME!

--- a/development/notifications.md
+++ b/development/notifications.md
@@ -1,0 +1,41 @@
+---
+title: Notifications
+---
+
+# Introduction
+The MagicMirror core has the ability to send notifications to modules. Or even better: the modules have the possibility
+ to send notifications to other modules.
+
+Additional technical information on the notifications can be found in the [modules documentation](https://docs.magicmirror.builders/development/introduction.html#general-advice):
+- [notificationReceived](https://docs.magicmirror.builders/development/core-module-file.html#subclassable-module-methods)
+- [sendNotification](https://docs.magicmirror.builders/development/core-module-file.html#module-instance-methods)
+
+# System notifications
+The system sends three notifications when starting up:
+
+Notification            | Payload | Description
+----------------------- | ------- | -----------
+| `ALL_MODULES_STARTED` | _none_  | All modules are started. You can now send notifications to other modules.
+| `DOM_OBJECTS_CREATED` | _none_  | All dom objects are created. The system is now ready to perform visual changes.
+| `MODULE_DOM_CREATED`  | _none_  | This module's dom has been fully loaded. You can now access your module's dom objects.
+
+# Default module notifications
+These notifications are send by the default modules:
+
+Notification              | Payload  | Description
+------------------------- | -------- | -----------
+| `SHOW_ALERT`            | [message details](https://github.com/MichMich/MagicMirror/tree/master/modules/default/alert#notification-params) | Sent to [alert module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/alert) to show an alert or notification.
+| `HIDE_ALERT`            | _none_   | Sent to [alert module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/alert) to hide the current alert or notification.
+| `CALENDAR_EVENTS`       | [calendar events](https://github.com/MichMich/MagicMirror/tree/master/modules/default/calendar) | Sent by [calendar module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/calendar) to inform modules of the calendar events. The [currentweather module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/currentweather) uses this event to display the weather for the location of an upcoming event.
+| `CURRENTWEATHER_DATA`   | _TBC_    | Sent by [currentweather module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/currentweather)
+| `INDOOR_TEMPERATURE`    | _number_ | Sent to [currentweather module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/currentweather) to show indoor temperature.
+| `INDOOR_HUMIDITY`       | _number_ | Sent to [currentweather module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/currentweather) to show indoor humidity.
+| `ARTICLE_NEXT`          | _none_   | Shows the next news title in [newsfeed module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/newsfeed).
+| `ARTICLE_PREVIOUS`      | _none_   |  Shows the previous news title in [newsfeed module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/newsfeed).
+| `ARTICLE_MORE_DETAILS`  | _none_   |  Shows more details in [newsfeed module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/newsfeed).
+| `ARTICLE_LESS_DETAILS`  | _none_   |  Hides the summary or full news article and only displays the news title of the currently viewed news item in [newsfeed module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/newsfeed).
+| `ARTICLE_TOGGLE_FULL`   | _none_   |  Toogles article in fullscreen in [newsfeed module](https://github.com/MichMich/MagicMirror/tree/master/modules/default/newsfeed).
+
+# 3rd Party Module notifications
+
+Take a look in the [wiki](https://github.com/MichMich/MagicMirror/wiki/) to see if 3rd party modules send notifications you might want to use.

--- a/getting-started/autostart.md
+++ b/getting-started/autostart.md
@@ -1,0 +1,165 @@
+# Autostarting your MagicMirror
+
+The methods below describe ways to automatically start your MagicMirror on boot, and even ways to keep it running in case of a failure. 
+
+## Using PM2
+PM2 is a production process manager for Node.js applications with a built-in load balancer. It allows you to keep applications alive forever, to reload them without downtime and to facilitate common system admin tasks. In this case we will use it to keep a shell script running.
+
+### Install PM2
+Install PM2 using NPM:
+````
+sudo npm install -g pm2
+````
+
+### Starting PM2 on Boot
+To make sure PM2 can do it's job when (re)booting your operating system, it needs to be started on boot. Luckily, PM2 has a handy helper for this. 
+````
+pm2 startup
+````
+PM2 will now show you a command you need to execute.
+
+### Make a MagicMirror start script.
+To use PM2 in combination with MagicMirror, we need to make a simple shell script. Preferable, we put this script outside the MagicMirror folder to make sure it won't give us any issues if we want to upgrade the mirror.
+````shell
+cd ~
+nano mm.sh
+````
+Add the following lines:
+````shell
+cd ./MagicMirror
+DISPLAY=:0 npm start
+````
+Save and close, using the commands `CTRL-O` and `CTRL-X`.
+Now make sure the shell script is executable by performing the following command:
+````shell
+chmod +x mm.sh
+````
+You are now ready to the MagicMirror using this script using PM2.
+
+### Starting your MagicMirror with PM2
+Simply start your mirror with the following command:
+````shell
+pm2 start mm.sh
+````
+You mirror should now boot up and appear on your screen after a few seconds.
+
+### Enable restarting of the MagicMirror script.
+To make sure the MagicMirror restarts after rebooting, you need to save the current state of all scripts running via PM2. To do this, execute the following command
+````shell
+pm2 save
+````
+
+And that's all there is! You MagicMirror should now reboot after start, and restart after any failure.
+
+### Controlling you MagicMirror via PM2.
+With your MagicMirror running via PM2, you have some handy tools at hand:
+#### Restarting your MagicMirror
+````shell
+pm2 restart mm
+````
+#### Stopping your MagicMirror
+````shell
+pm2 stop mm
+````
+#### Show the MagicMirror logs
+````shell
+pm2 logs mm
+````
+#### Show the MagicMirror process information
+````shell
+pm2 show mm
+````
+
+## Using systemd/systemctl
+Note: Systemctl is a control interface for systemd, a powerful service manager often found in full Linux systems.  This approach is most like only applicable for those using the "server only" setup running on a linux server.
+
+### Create service file
+To start, you'll need to create a config file via your editor of choice (nano used in these examples):
+```
+sudo nano /etc/systemd/system/magicmirror.service
+```
+Place the below text into your new file, modify as needed (see notes below) then save & exit.
+Notes:
+The example assumes your Magic Mirror is installed in the "WorkingDirectory" of "/home/server/MagicMirror/" and your node install is located at "/usr/bin/node" (run `which node` if you're unsure where to find node) this means your full manual start command would be "/usr/bin/node /home/server/MagicMirror/serveronly".  While you almost certainly don't type this all out when you run manually, systemctl requires full paths.  This example also assumes you have an existing Linux user of "server", but any user will do.  "root" will certainly work but has the potential to do more damage, so you should avoid it if possible.
+```
+[Unit]
+Description=Magic Mirror
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=server
+WorkingDirectory=/home/server/MagicMirror/
+ExecStart=/usr/bin/node serveronly
+
+[Install]
+WantedBy=multi-user.target
+```
+### Control MM with systemctl
+Now try starting MM with the commands below.  If start is successful work, use the 'enable' command below to automatically start when MM fails or is rebooted.  If MM does not start, use the "status" command below to see most recent errors.
+
+Note: For any of the below commands 'magicmirror.service` can be replaced with `magicmirror` as systemd will automatically look for `*.service`
+
+#### Start MM with systemctl
+```
+sudo systemctl start magicmirror.service
+```
+
+#### Stop MM with systemctl
+```
+sudo systemctl stop magicmirror.service
+```
+
+#### To check the status of Magic Mirror
+```
+sudo systemctl status magicmirror.service
+```
+#### Allow autostart Magic Mirror on boot
+Note: does not start immediately, need to run start command or reboot
+```
+sudo systemctl enable magicmirror.service
+```
+
+#### Disable autostart of Magic Mirror
+```
+sudo systemctl disable magicmirror.service
+```
+
+### Autostart browser for server mode
+
+Create file `/home/server/.config/lxsession/LXDE-pi/autostart` with the following contents:
+
+```
+@lxpanel --profile LXDE-pi
+@pcmanfm --desktop --profile LXDE-pi
+@xscreensaver -no-splash
+@point-rpi
+@sh /home/server/bin/start-chromium.sh
+```
+
+Create file `/home/server/bin/start-chromium.sh` with the following contents:
+
+```
+#!/bin/sh
+
+set -e
+
+CHROMIUM_TEMP=~/tmp/chromium
+rm -Rf ~/.config/chromium/
+rm -Rf $CHROMIUM_TEMP
+mkdir -p $CHROMIUM_TEMP
+
+chromium-browser \
+        --disable \
+        --disable-translate \
+        --disable-infobars \
+        --disable-suggestions-service \
+        --disable-save-password-bubble \
+        --disk-cache-dir=$CHROMIUM_TEMP/cache/ \
+        --user-data-dir=$CHROMIUM_TEMP/user_data/ \
+        --start-maximized \
+        --kiosk http://localhost:8080 &
+```

--- a/getting-started/configuration.md
+++ b/getting-started/configuration.md
@@ -4,7 +4,7 @@
 
 The following wiki links are helpful for the initial configuration of your MagicMirror² operating system:
 - [Configuring the Raspberry Pi](https://github.com/MichMich/MagicMirror/wiki/Configuring-the-Raspberry-Pi)
-- [Auto Starting MagicMirror](https://github.com/MichMich/MagicMirror/wiki/Auto-Starting-MagicMirror)
+- [Auto Starting MagicMirror](https://docs.magicmirror.builders/getting-started/autostart.html)
 
 
 ## General

--- a/modules/alert.md
+++ b/modules/alert.md
@@ -56,10 +56,10 @@ self.sendNotification("SHOW_ALERT", {});
 | `title`                                         | The title of the alert. <br><br> **Possible values:** `text` or `html`
 | `message`                                       | The message of the alert. <br><br> **Possible values:** `text` or `html`
 | `imageUrl` (optional)                           | Image to show in the alert <br><br> **Possible values:** `url` `path` <br> **Default value:** `none`
-| `imageFA` (optional)                            | Font Awesome icon to show in the alert <br><br> **Possible values:** See [Font Awesome](http://fontawesome.io/icons/) website. <br> **Default value:** `none`
+| `imageFA` (optional)                            | Font Awesome icon to show in the alert <br><br> **Possible values:** See [Font Awesome](https://fontawesome.io/icons/) website. <br> **Default value:** `none`
 | `imageHeight` (optional even with imageUrl set) | Height of the image <br><br> **Possible values:** `intpx` <br> **Default value:** `80px`
 | `timer` (optional)                              | How long the alert should stay visible in ms. <br> **Important:** If you do not use the `timer`, it is your duty to hide the alert by using `self.sendNotification("HIDE_ALERT");`! <br><br>**Possible values:** `int` `float` <br> **Default value:** `none`
 
 ## Open Source Licenses
 ### [NotificationStyles](https://github.com/codrops/NotificationStyles)
-See [tympanus.net](http://tympanus.net/codrops/licensing/) for license.
+See [tympanus.net](https://tympanus.net/codrops/licensing/) for license.

--- a/modules/calendar.md
+++ b/modules/calendar.md
@@ -44,10 +44,10 @@ The following properties can be configured:
 | `calendars`                  | The list of calendars. <br><br> **Possible values:** An array, see _calendar configuration_ below. <br> **Default value:** _An example calendar._
 | `titleReplace`               | An object of textual replacements applied to the tile of the event. This allow to remove or replace certain words in the title. <br><br> **Example:** `{'Birthday of ' : '', 'foo':'bar'}` <br> **Default value:** `{	"De verjaardag van ": "", "'s birthday": ""	}`
 | `displayRepeatingCountTitle` | Show count title for yearly repeating events (e.g. "X. Birthday", "X. Anniversary") <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
-| `dateFormat`                 | Format to use for the date of events when using absolute dates. (version <= 2.16.0) From version 2.16.0, this option will be used to format absolute and relative dates. (e.g. DD/MM/YY to change from the default MM/DD/YYYY) <br><br> **Possible values:** See [Moment.js formats](http://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
+| `dateFormat`                 | Format to use for the date of events when using absolute dates. (version <= 2.16.0) From version 2.16.0, this option will be used to format absolute and relative dates. (e.g. DD/MM/YY to change from the default MM/DD/YYYY) <br><br> **Possible values:** See [Moment.js formats](https://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
 | `dateEndFormat`              | Format to use for the end time of events <br><br> **Possible values:** See [Moment.js formats](https://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `HH:mm` (e.g. 16:30)
 | `showEnd`                    | Show end time of events  <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
-| `fullDayEventDateFormat`     | Format to use for the date of full day events (when using absolute dates) <br><br> **Possible values:** See [Moment.js formats](http://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
+| `fullDayEventDateFormat`     | Format to use for the date of full day events (when using absolute dates) <br><br> **Possible values:** See [Moment.js formats](https://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
 | `timeFormat`                 | Display event times as absolute dates, or relative time, or using absolute date headers with times for each event next to it <br><br> **Possible values:** `absolute` or `relative` or `dateheaders` <br> **Default value:** `relative`
 | `showEnd`                    | Display the end of a date as well <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `getRelative`                | How much time (in hours) should be left until calendar events start getting relative? <br><br> **Possible values:** `0` (events stay absolute) - `48` (48 hours before the event starts) <br> **Default value:** `6`
@@ -77,7 +77,7 @@ config: {
 	coloredSymbolOnly: false,
 	calendars: [
 		{
-			url: 'http://www.calendarlabs.com/templates/ical/US-Holidays.ics',
+			url: 'https://www.calendarlabs.com/templates/ical/US-Holidays.ics',
 			symbol: 'calendar',
 			auth: {
 			    user: 'username',
@@ -94,7 +94,7 @@ config: {
 | Option                | Description
 | --------------------- | -----------
 | `url`	                | The url of the calendar .ical. This property is required. <br><br> **Possible values:** Any public accessible .ical calendar.
-| `symbol`              | The symbol to show in front of an event. This property is optional. <br><br> **Possible values:** See [Font Awesome](http://fontawesome.io/icons/) website. To have multiple symbols you can define them in an array e.g. `["calendar", "plane"]`
+| `symbol`              | The symbol to show in front of an event. This property is optional. <br><br> **Possible values:** See [Font Awesome](https://fontawesome.io/icons/) website. To have multiple symbols you can define them in an array e.g. `["calendar", "plane"]`
 | `color`               | The font color of an event from this calendar. This property should be set if the config is set to colored: true. <br><br> **Possible values:** HEX, RGB or RGBA values (#efefef, rgb(242,242,242), rgba(242,242,242,0.5)).
 | `repeatingCountTitle`	| The count title for yearly repeating events in this calendar.  <br><br> **Example:** `'Birthday'`
 | `maximumEntries`      | The maximum number of events shown.  Overrides global setting. **Possible values:** `0` - `100`

--- a/modules/calendar.md
+++ b/modules/calendar.md
@@ -23,13 +23,12 @@ modules: [
 
 The following properties can be configured:
 
-
 | Option                       | Description
 | ---------------------------- | -----------
 | `maximumEntries`             | The maximum number of events shown. / **Possible values:** `0` - `100` <br> **Default value:** `10`
 | `maximumNumberOfDays`        | The maximum number of days in the future. <br><br> **Default value:** `365`
 | `displaySymbol`              | Display a symbol in front of an entry. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
-| `defaultSymbol`              | The default symbol. <br><br> **Possible values:** See [Font Awesome](http://fontawesome.io/icons/) website. <br> **Default value:** `calendar`
+| `defaultSymbol`              | The default symbol. <br><br> **Possible values:** See [Font Awesome](https://fontawesome.io/icons/) website. <br> **Default value:** `calendar`
 | `showLocation`               | Whether to show event locations. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `maxTitleLength`             | The maximum title length. <br><br> **Possible values:** `10` - `50` <br> **Default value:** `25`
 | `maxLocationTitleLength`     | The maximum location title length. <br><br> **Possible values:** `10` - `50` <br> **Default value:** `25`
@@ -46,7 +45,7 @@ The following properties can be configured:
 | `titleReplace`               | An object of textual replacements applied to the tile of the event. This allow to remove or replace certain words in the title. <br><br> **Example:** `{'Birthday of ' : '', 'foo':'bar'}` <br> **Default value:** `{	"De verjaardag van ": "", "'s birthday": ""	}`
 | `displayRepeatingCountTitle` | Show count title for yearly repeating events (e.g. "X. Birthday", "X. Anniversary") <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `dateFormat`                 | Format to use for the date of events when using absolute dates. (version <= 2.16.0) From version 2.16.0, this option will be used to format absolute and relative dates. (e.g. DD/MM/YY to change from the default MM/DD/YYYY) <br><br> **Possible values:** See [Moment.js formats](http://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
-| `dateEndFormat`              | Format to use for the end time of events <br><br> **Possible values:** See [Moment.js formats](http://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `HH:mm` (e.g. 16:30)
+| `dateEndFormat`              | Format to use for the end time of events <br><br> **Possible values:** See [Moment.js formats](https://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `HH:mm` (e.g. 16:30)
 | `showEnd`                    | Show end time of events  <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `fullDayEventDateFormat`     | Format to use for the date of full day events (when using absolute dates) <br><br> **Possible values:** See [Moment.js formats](http://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
 | `timeFormat`                 | Display event times as absolute dates, or relative time, or using absolute date headers with times for each event next to it <br><br> **Possible values:** `absolute` or `relative` or `dateheaders` <br> **Default value:** `relative`
@@ -71,6 +70,7 @@ The `colored` property gives the option for an individual color for each calenda
 The `coloredSymbolOnly` property will apply color to the symbol only, not the whole line. This is only applicable when `colored` is also enabled.
 
 #### Default value:
+
 ````javascript
 config: {
 	colored: false,
@@ -90,6 +90,7 @@ config: {
 ````
 
 #### Calendar configuration options:
+
 | Option                | Description
 | --------------------- | -----------
 | `url`	                | The url of the calendar .ical. This property is required. <br><br> **Possible values:** Any public accessible .ical calendar.
@@ -105,10 +106,43 @@ config: {
 | `timeClass`           | Add a class to the time's cell.
 | `broadcastPastEvents` | Whether to include past events from this calendar.  Overrides global setting
 
-
 #### Calendar authentication options:
+
 | Option                | Description
 | --------------------- | -----------
 | `user`                | The username for HTTP authentication.
 | `pass`                | The password for HTTP authentication. (If you use Bearer authentication, this should be your BearerToken.)
 | `method`              | Which authentication method should be used. HTTP Basic, Digest and Bearer authentication methods are supported. Basic authentication is used by default if this option is omitted. **Possible values:** `digest`, `basic`, `bearer` **Default value:** `basic`
+
+
+## Syncing your Microsoft, Google and Apple calendars
+
+To be able to use your calendar with Microsoft Outlook, Google Calendar and Apple iCal calendars, 
+you need to either add each, individually or find a way to sync them into one. There are several 
+free and non-free software that can help you do this.
+
+For example, in [this forum thread](https://forum.magicmirror.builders/topic/5327/sync-private-icloud-calendar-with-magicmirror/50?page=1) are instructions how to sync with `iCal`. 
+
+### Two-way Syncing
+
+Here are some various projects that can be used to sync your calendars into one. 
+
+* https://github.com/phw198/OutlookGoogleCalendarSync
+* https://github.com/Dashbrd/CalendarSyncplus
+* https://www.sync2.com/Download.aspx
+* https://www.pppindia.com/calendar-sync/index.html
+* https://www.fieldstonsoftware.com/software/gsyncit5/Download.aspx
+* https://tools.google.com/dlpage/gappssync
+* https://www.lifewire.com/how-to-sync-google-calendar-outlook-and-iphone-calendar-1172188
+* https://www.makeuseof.com/tag/how-to-sync-microsoft-outlook-with-google-calendar/
+
+### Office 365 Calendar Support
+
+Office 365 calendars create date formats that are incompatible with MM2.
+Here are the instructions to fix it:
+
+1. Import your Office 365 calendar into a Google Calendar. This will take care of all the previous events of your calendar.
+2. Go to [Microsoft Flow](https://flow.microsoft.com) and setup a Flow trigger that will create a new event in your Google Calendar whenever an event in Office 365 is created. [Here is a guide to help with this task.](https://shift.newco.co/sync-your-calendars-using-microsoft-flow-and-yes-google-calendar-works-too-a28be5a604dd)
+3. Go to Google Calendar and create a private address to use in the calendar module for your Magic Mirror.
+
+This trigger will run every 5 minutes. Make sure to give it time after you create a new event in Office 365 to appear in Google Calendar. Past events will NOT be created using Flow; to do this, follow step 1 to import your calendar into Google Calendar.

--- a/modules/clock.md
+++ b/modules/clock.md
@@ -42,7 +42,7 @@ The following properties can be configured:
 | `showMoonTimes`   | Turn off or on the section showing moonrise and moonset times (digital clock only). <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `lat`             | Latitude for sun/moon calculations. <br><br> **Default value:** `47.630539`
 | `lon`             | Longitude for sun/moon calculations. <br><br> **Default value:** `-122.344147`
-| `dateFormat`      | Configure the date format as you like. <br><br> **Possible values:** [Docs](http://momentjs.com/docs/#/displaying/format/) <br> **Default value:** `"dddd, LL"`
+| `dateFormat`      | Configure the date format as you like. <br><br> **Possible values:** [Docs](https://momentjs.com/docs/#/displaying/format/) <br> **Default value:** `"dddd, LL"`
 | `displayType`     | Display a digital clock, analog clock, or both together. <br><br> **Possible values:** `digital`, `analog`, or `both` <br> **Default value:** `digital`
 | `analogSize`      | **Specific to the analog clock.** Defines how large the analog display is. <br><br> **Possible values:** `A positive number of pixels` <br> **Default value:** `200px`
 | `analogFace`      | **Specific to the analog clock.** Specifies which clock face to use. <br><br> **Possible values:** `simple` for a simple border, `none` for no face or border, or `face-###` (where ### is currently a value between 001 and 012, inclusive) <br> **Default value:** `simple`

--- a/modules/currentweather.md
+++ b/modules/currentweather.md
@@ -23,7 +23,7 @@ modules: [
 		config: {
 			// See 'Configuration options' for more information.
 			location: "Amsterdam,Netherlands",
-			locationID: "", //Location ID from http://bulk.openweathermap.org/sample/city.list.json.gz
+			locationID: "", //Location ID from https://bulk.openweathermap.org/sample/city.list.json.gz
 			appid: "abcde12345abcde12345abcde12345ab" //openweathermap.org API key.
 		}
 	}
@@ -62,7 +62,7 @@ The following properties can be configured:
 | `initialLoadDelay`           | The initial delay before loading. If you have multiple modules that use the same API key, you might want to delay one of the requests. (Milliseconds) <br><br> **Possible values:** `1000` - `5000` <br> **Default value:**  `0`
 | `retryDelay`                 | The delay before retrying after a request failure. (Milliseconds) <br><br> **Possible values:** `1000` - `60000` <br> **Default value:**  `2500`
 | `apiVersion`                 | The OpenWeatherMap API version to use. <br><br> **Default value:**  `2.5`
-| `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'http://api.openweathermap.org/data/'`
+| `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'https://api.openweathermap.org/data/'`
 | `weatherEndpoint`	           | The OpenWeatherMap API endPoint. <br><br> **Default value:**  `'weather'`
 | `appendLocationNameToHeader` | If set to `true`, the returned location name will be appended to the header of the module, if the header is enabled. This is mainly interesting when using calender based weather. <br><br> **Default value:**  `true`
 | `useLocationAsHeader`        | If set to `true` and location is given a value, the value of location will be used as the header. This is useful if `locationName` was not returned. <br><br> **Default value:** `false`

--- a/modules/customcss.md
+++ b/modules/customcss.md
@@ -9,7 +9,7 @@ One common request is to make the weather icons colorful, this can easily be ach
 }
 ```
 
-MagicMirror² uses these weather icons: [http://erikflowers.github.io/weather-icons/](http://erikflowers.github.io/weather-icons/).
+MagicMirror² uses these weather icons: [https://erikflowers.github.io/weather-icons/](http://erikflowers.github.io/weather-icons/).
 On that page you can find what class name is used for the displayed icon and add it to your `custom.css`-file like in the example above.
 
 ### Target a specific module

--- a/modules/newsfeed.md
+++ b/modules/newsfeed.md
@@ -23,11 +23,11 @@ modules: [
 			feeds: [
 				{
 					title: "New York Times",
-					url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+					url: "https://www.nytimes.com/services/xml/rss/nyt/HomePage.xml",
 				},
 				{
 					title: "BBC",
-					url: "http://feeds.bbci.co.uk/news/video_and_audio/news_front_page/rss.xml?edition=uk",
+					url: "https://feeds.bbci.co.uk/news/video_and_audio/news_front_page/rss.xml?edition=uk",
 				},
 			]
 		}
@@ -73,7 +73,7 @@ The following properties can be configured:
 
 | Option             | Description
 | ------------------ | -----------
-| `feeds`            | An array of feed urls that will be used as source. <br> More info about this object can be found below. <br> **Default value:** `[{ title: "New York Times", url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml", encoding: "UTF-8" }]`<br>You can add `reloadInterval` option to set particular reloadInterval to a feed.
+| `feeds`            | An array of feed urls that will be used as source. <br> More info about this object can be found below. <br> **Default value:** `[{ title: "New York Times", url: "https://www.nytimes.com/services/xml/rss/nyt/HomePage.xml", encoding: "UTF-8" }]`<br>You can add `reloadInterval` option to set particular reloadInterval to a feed.
 | `showAsList`       | Display the news as a list. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showSourceTitle`  | Display the title of the source. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `showPublishDate`  | Display the publish date of an headline. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
@@ -104,5 +104,5 @@ The `feeds` property contains an array with multiple objects. These objects have
 | Option     | Description
 | ---------- | -----------
 | `title`    | The name of the feed source to be displayed above the news items. <br><br> This property is optional.
-| `url`      | The url of the feed used for the headlines. <br><br> **Example:** `'http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml'`
+| `url`      | The url of the feed used for the headlines. <br><br> **Example:** `'https://www.nytimes.com/services/xml/rss/nyt/HomePage.xml'`
 | `encoding` | The encoding of the news feed. <br><br> This property is optional. <br> **Possible values:**`'UTF-8'`, `'ISO-8859-1'`, etc ... <br> **Default value:** `'UTF-8'`

--- a/modules/weather.md
+++ b/modules/weather.md
@@ -86,7 +86,7 @@ The following properties can be configured:
 | Option                       | Description
 | ---------------------------- | -----------
 | `apiVersion`                 | The OpenWeatherMap API version to use. <br><br> **Default value:** `2.5`
-| `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:** `'http://api.openweathermap.org/data/'`
+| `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:** `'https://api.openweathermap.org/data/'`
 | `weatherEndpoint`	           | The OpenWeatherMap API endPoint. <br><br> **Possible values:** `'/weather'` , `'/onecall'` , `'/forecast'` (free users) or `'/forecast/daily'` (paying users or old apiKey only) <br> **Default value:** `'/weather'`
 | `locationID`                 | Location ID from [OpenWeatherMap](https://openweathermap.org/find) **This will override anything you put in location.** <br> Leave blank if you want to use location. <br> **Example:** `1234567` <br> **Default value:** `false` <br><br> **Note:** When the `location` and `locationID` are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
 | `location`                   | The location used for weather information. <br><br> **Example:** `'Amsterdam,Netherlands'` <br> **Default value:** `false` <br><br> **Note:** When the `location` and `locationID` are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
@@ -117,7 +117,7 @@ The following properties can be configured:
 
 | Option                       | Description
 | ---------------------------- | -----------
-| `apiBase`                    | The UKMO base URL. <br><br> **Possible value:**  `'http://datapoint.metoffice.gov.uk/public/data/val/wxfcs/all/json/'` <br>  This value is **REQUIRED**
+| `apiBase`                    | The UKMO base URL. <br><br> **Possible value:**  `'https://datapoint.metoffice.gov.uk/public/data/val/wxfcs/all/json/'` <br>  This value is **REQUIRED**
 | `locationID`	               | The UKMO API location code. <br><br> **Possible values:** `322942` <br>  This value is **REQUIRED**
 | `apiKey`                     | The [UK Met Office](https://www.metoffice.gov.uk/datapoint/getting-started) API key, which can be obtained by creating an UKMO Datapoint account. <br><br>  This value is **REQUIRED**
 

--- a/modules/weatherforecast.md
+++ b/modules/weatherforecast.md
@@ -23,7 +23,7 @@ modules: [
 		config: {
 			// See 'Configuration options' for more information.
 			location: "Amsterdam,Netherlands",
-			locationID: "", //Location ID from http://bulk.openweathermap.org/sample/city.list.json.gz
+			locationID: "", //Location ID from https://bulk.openweathermap.org/sample/city.list.json.gz
 			appid: "abcde12345abcde12345abcde12345ab" //openweathermap.org API key.
 		}
 	}
@@ -54,7 +54,7 @@ The following properties can be configured:
 | `initialLoadDelay`           | The initial delay before loading. If you have multiple modules that use the same API key, you might want to delay one of the requests. (Milliseconds) <br><br> **Possible values:** `1000` - `5000` <br> **Default value:**  `2500` (2.5 seconds delay. This delay is used to keep the OpenWeather API happy.)
 | `retryDelay`                 | The delay before retrying after a request failure. (Milliseconds) <br><br> **Possible values:** `1000` - `60000` <br> **Default value:**  `2500`
 | `apiVersion`                 | The OpenWeatherMap API version to use. <br><br> **Default value:**  `2.5`
-| `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'http://api.openweathermap.org/data/'`
+| `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'https://api.openweathermap.org/data/'`
 | `forecastEndpoint`           | The OpenWeatherMap API endPoint. <br><br> **Default value:**  `'forecast/daily'`
 | `excludes`                   | Exclude some parts of the weather data from the API response. It should be a comma-delimited list (without spaces). <br><br> **Default value:**  `false`
 | `appendLocationNameToHeader` | If set to `true`, the returned location name will be appended to the header of the module, if the header is enabled. This is mainly interesting when using calender based weather. <br><br> **Default value:**  `true`


### PR DESCRIPTION
This PR moves some pages from the wiki to the more visible Documentation page as discussed in https://github.com/MichMich/MagicMirror/issues/2545:

- Notifications in the MM
- Autostarting your MM
- How to write Documentation for your own module
- Syncing infos for your calendars

Also the pages use https for all links now.