### PR TITLE
Use the logger in node_helper.js

### DIFF
--- a/development/logger.md
+++ b/development/logger.md
@@ -1,10 +1,16 @@
 # Logger
 
-The Magic Mirror contains a convenience wrapper for logging. Currently, this logger is a simple proxy to the original `console.log` methods. But it might get additional features in the future. The Loggers is currently only available in the core module file (not in the node_helper).
+The Magic Mirror contains a convenience wrapper for logging. Currently, this logger is a simple proxy to the original `console.log` methods. But it might get additional features in the future.
 
 **Examples:**
-````javascript
+```javascript
 Log.info('error');
 Log.log('log');
 Log.error('info');
-````
+```
+
+By default, the logger is only available in the core module file. If you want to use the logger in the `node_helper.js`, you have to add it by inserting the following line at the beginning of the file:
+
+```javascript
+const Log = require("logger");
+```


### PR DESCRIPTION
I don't know if that's such a good approach, but I've seen it in some modules and I use it that way myself.