### PR TITLE
update npm install command to exclude dev dependencies

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -10,13 +10,13 @@ Therefore the only officially supported way of installation is by using a [manua
 - `sudo apt install -y nodejs`
 2. Clone the repository and check out the master branch: `git clone https://github.com/MichMich/MagicMirror`
 3. Enter the repository: `cd MagicMirror/`
-4. Install the application: `npm install`
+4. Install the application: `npm install --only=prod --omit=dev`
 5. Make a copy of the config sample file: `cp config/config.js.sample config/config.js`
 6. Start the application: `npm run start` \
    For **Server Only** use: `npm run server` .
 
 ::: warning NOTE
-The installation step for `npm install` will take a very long time, often with little or no terminal response! For the RPi3 this is **~10** minutes and for the Rpi2 **~25** minutes. Do not interrupt or you risk getting a :broken_heart: by Raspberry Jam.
+The installation step for `npm install --only=prod --omit=dev` will take a very long time, often with little or no terminal response! For the RPi3 this is **~10** minutes and for the Rpi2 **~25** minutes. Do not interrupt or you risk getting a :broken_heart: by Raspberry Jam.
 :::
 
 ## Alternative Installation Methods

--- a/getting-started/upgrade-guide.md
+++ b/getting-started/upgrade-guide.md
@@ -6,7 +6,7 @@ Always backup your `config.js`, `custom.css` and `modules` folder before you sta
 
 If you want to update your MagicMirror² to the latest version, use your terminal to go to your Magic Mirror folder and type the following command:
 ```
-git pull && npm install
+git pull && npm install --only=prod --omit=dev
 ```
 
 If you changed nothing more than the config or the modules, this should work without any problems. Type git status to see your changes, if there are any, you can reset them with `git reset --hard`. After that, git pull should be possible.


### PR DESCRIPTION
* this improves install speeds dramatically
* tested with `npm run server` on NPM v6 and v8 (but please test yourself again as I couldn't spin up a desktop environment for `npm run start`)

using `--only=prod` for legacy npm clients (https://docs.npmjs.com/cli/v6/commands/npm-install)
using `--omit=dev` for v7+(https://docs.npmjs.com/cli/v7/commands/npm-install)