### PR TITLE
update migration guide

### DIFF
--- a/modules/currentweather.md
+++ b/modules/currentweather.md
@@ -101,7 +101,7 @@ The following lines needs to be changed when migrating to the new weather module
 
 ```json {2,5,8}
 {
-  "module": "weatherforecast",
+  "module": "currentweather",
   "position": "top_right",
   "config": {
     "location": "Amsterdam,Netherlands",


### PR DESCRIPTION
migration guide for currentweather module should show "currentweather" for the old module name instead of "weatherforecast"