### PR TITLE
docs(Magic Mirror doc): :memo: fixed the path to header.png in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 title: Introduction
 ---
 
-![MagicMirror²: The open source modular smart mirror platform. ](header.png)
+![MagicMirror²: The open source modular smart mirror platform. ](./.vuepress/public/header.png)
 
 <p style="text-align: center">
 	<a href="https://choosealicense.com/licenses/mit">


### PR DESCRIPTION
Hi!

I noticed that when looking at the documentation project page in GitHub, the logo was missing. The file header.png is already in the `./vuepress/public` folder so I changed it to that path.

Please check that in the final VuePress build of the documentation the logo is also there (it was in my local test).

Kind regards,
-Thomas