### PR TITLE
minor changes

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -92,7 +92,7 @@ Note the following:
 
 ### Server Only
 
-In some cases, you want to start the application without an actual app window. In this case, you can start MagicMirror² in server only mode by manually running `npm run server` or using Docker. This will start the server, after which you can open the application in your browser of choice. Detailed description below.
+In some cases, you want to start the application without an actual app window. In this case, you can start MagicMirror² in server only mode by manually running `npm run server`. This will start the server, after which you can open the application in your browser of choice. Detailed description below.
 
 ::: warning IMPORTANT
 Make sure that you whitelist the interface/ip (`ipWhitelist`) in the server config where you want the client to connect to, otherwise it will not be allowed to connect to the server. You also need to set the local host `address` field to `0.0.0.0` in order for the RPi to listen on all interfaces and not only `localhost` (default).

--- a/getting-started/upgrade-guide.md
+++ b/getting-started/upgrade-guide.md
@@ -7,7 +7,7 @@ Always backup your `config.js`, `custom.css` and `modules` folder before you sta
 If you want to update your MagicMirror² to the latest version, use your terminal to go to your Magic Mirror folder and type the following command:
 
 ```
-git pull && npm install --only=prod --omit=dev
+git pull && npm run install-mm
 ```
 
 If you changed nothing more than the config or the modules, this should work without any problems.


### PR DESCRIPTION
- remove docker sentence in server only description which was a restriction of old docker setup, current docker setup runs on raspberry pi and as server only
- update upgrade command to command used for install

can be merged immediately, has not to wait for next release