### PR TITLE
Allow `npm run local:dev` for local develop (without https)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "npm run docs:dev",
     "docs:dev": "vuepress dev .",
     "docs:build": "vuepress build .",
+    "local:dev": "NODE_OPTIONS=--openssl-legacy-provider npm start",
     "check": "vuepress check-md .",
     "lint": "prettier . --write"
   }


### PR DESCRIPTION
For local develop and don't check https
it will use http only 