### PR TITLE
add node18 as required, remove digest from calendar auth

### DIFF
--- a/getting-started/requirements.md
+++ b/getting-started/requirements.md
@@ -30,4 +30,5 @@ Raspberry Pi OS versions based on Debian "Stretch" are also no longer supported.
 
 ## Node
 
-Although older version of Node might work, we suggest you use Node 18.
+Node 18 is required, all older versions have reached end of life and will not
+work.

--- a/modules/calendar.md
+++ b/modules/calendar.md
@@ -120,11 +120,11 @@ config: {
 
 #### Calendar authentication options:
 
-| Option   | Description                                                                                                                                                                                                                                                   |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `user`   | The username for HTTP authentication.                                                                                                                                                                                                                         |
-| `pass`   | The password for HTTP authentication. (If you use Bearer authentication, this should be your BearerToken.)                                                                                                                                                    |
-| `method` | Which authentication method should be used. HTTP Basic, Digest and Bearer authentication methods are supported. Basic authentication is used by default if this option is omitted.**Possible values:** `digest`, `basic`, `bearer` **Default value:** `basic` |
+| Option   | Description                                                                                                                                                                                                                                 |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user`   | The username for HTTP authentication.                                                                                                                                                                                                       |
+| `pass`   | The password for HTTP authentication. (If you use Bearer authentication, this should be your BearerToken.)                                                                                                                                  |
+| `method` | Which authentication method should be used. HTTP Basic and Bearer authentication methods are supported. Basic authentication is used by default if this option is omitted.**Possible values:** `basic`, `bearer` **Default value:** `basic` |
 
 ## Syncing your Microsoft, Google and Apple calendars
 


### PR DESCRIPTION
I used `master` as base branch because this can merged immediately because
- node18 reaches end of life in a few days
- digest auth in calendar is not working since mm release `2.15.0`