### PR TITLE
Change npm run to node --run

### DIFF
--- a/getting-started/upgrade-guide.md
+++ b/getting-started/upgrade-guide.md
@@ -13,7 +13,7 @@ If you want to update your MagicMirror² to the latest version, use your termina
 to go to your MagicMirror folder and type the following command:
 
 ```shell
-git pull && npm run install-mm
+git pull && node --run install-mm
 ```
 
 If you changed nothing more than the config or the modules, this should work


### PR DESCRIPTION
All of the documentation with 2.32.0 seems to encourage using `node --run` instead of the previously used `npm run`, so I'm guessing this documentation should be updated with that as well.  I tested the command on my system and it seemed to run without error.