### PR TITLE
Standardize formatting

### DIFF
--- a/module-development/core-module-file.md
+++ b/module-development/core-module-file.md
@@ -634,7 +634,7 @@ translator to change the word order in the sentence to be translated.
 
 ```js
 const timeUntilEnd = moment(event.endDate, "x").fromNow(true);
-this.translate("RUNNING", { "timeUntilEnd": timeUntilEnd) }); // Will return a translated string for the identifier RUNNING, replacing `{timeUntilEnd}` with the contents of the variable `timeUntilEnd` in the order that translator intended.
+this.translate("RUNNING", { "timeUntilEnd": timeUntilEnd }); // Will return a translated string for the identifier RUNNING, replacing `{timeUntilEnd}` with the contents of the variable `timeUntilEnd` in the order that translator intended.
 ```
 
 **Example English.json file:**
@@ -663,9 +663,9 @@ did not support the word order, it is recommended to have the fallback layout.
 ```js
 const timeUntilEnd = moment(event.endDate, "x").fromNow(true);
 this.translate("RUNNING", {
-	"fallback": this.translate("RUNNING") + " {timeUntilEnd}"
-	"timeUntilEnd": timeUntilEnd
-)}); // Will return a translated string for the identifier RUNNING, replacing `{timeUntilEnd}` with the contents of the variable `timeUntilEnd` in the order that translator intended. (has a fallback)
+	"fallback": this.translate("RUNNING") + " {timeUntilEnd}",
+	"timeUntilEnd": timeUntilEnd,
+}); // Will return a translated string for the identifier RUNNING, replacing `{timeUntilEnd}` with the contents of the variable `timeUntilEnd` in the order that translator intended. (has a fallback)
 ```
 
 **Example Swedish.json file that does not have the variable in it:**


### PR DESCRIPTION
This just cleans up a bit of the formatting in the Core Module File page.

- d1e0a71d03ae6a3289794dfd7723ed9033ab83ad remove extraneous `...` from code blocks. The majority blocks do not have them on this page.
- 225b1dda4fad31704040e5631d4fb5c4aacb1685 Use the same "Example:" section header across the page
- 5173e7c8a089e8d3e8e7d972c5e0e3db6c45364d Fix some Javascript issues, think this was just an error