### PR TITLE
Add more custom CSS Details

### DIFF
--- a/modules/customcss.md
+++ b/modules/customcss.md
@@ -9,8 +9,12 @@ as an example of how to override the default variables.
 cp config/custom.css.sample config/custom.css
 ```
 
-The full main CSS file for MagicMirror² is located at
+The base CSS file for MagicMirror² is located at
 [`css/main.css`](https://github.com/MagicMirrorOrg/MagicMirror/blob/master/css/main.css).
+
+Each module can then have their own CSS styles located in their respective
+folders. For example the `weather` modules has its own CSS file located at
+[`defaultmodules/weather/weather.css`](https://github.com/MagicMirrorOrg/MagicMirror/blob/master/defaultmodules/weather/weather.css)
 
 ### Example
 

--- a/modules/customcss.md
+++ b/modules/customcss.md
@@ -16,6 +16,10 @@ Each module can then have their own CSS styles located in their respective
 folders. For example the `weather` modules has its own CSS file located at
 [`defaultmodules/weather/weather.css`](https://github.com/MagicMirrorOrg/MagicMirror/blob/master/defaultmodules/weather/weather.css)
 
+The `custom.css` file is loaded after all the default CSS files, so any styles
+you add there will override the default styles. You should not edit any of the
+default files directly.
+
 ### Example
 
 One common request is to make the weather icons colorful, this can easily be

--- a/modules/customcss.md
+++ b/modules/customcss.md
@@ -1,7 +1,16 @@
 # Custom CSS
 
 MagicMirror² comes with a default theme but it can be customized by placing a
-custom css-file in `config/custom.css`.
+custom CSS file at `config/custom.css`. You can start with
+[`config/custom.css.sample`](https://github.com/MagicMirrorOrg/MagicMirror/blob/master/config/custom.css.sample)
+as an example of how to override the default variables.
+
+```sh
+cp config/custom.css.sample config/custom.css
+```
+
+The full main CSS file for MagicMirror² is located at
+[`css/main.css`](https://github.com/MagicMirrorOrg/MagicMirror/blob/master/css/main.css).
 
 ### Example
 


### PR DESCRIPTION
There is not too much details on the Custom CSS page. This is simple info, but may not be obvious to all users.

Question for future dev, I wonder if the name "Custom CSS" is the right name for this page. 

It might make sense for us to call it "Custom Stylings" or "Custom Theme" or something with a less specific technical name for folks who might otherwise be able to figure it out once they have the sample. Could also be "Custom Stylings (CSS)" or the like if we want to cover our bases.