### PR TITLE
ci: run PR checks also for develop PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "javascript"

--- a/.github/workflows/autoupdate_develop.yaml
+++ b/.github/workflows/autoupdate_develop.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Merge master back to develop
         run: |
           git config --local user.email "actions@github.com"

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -19,7 +19,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Build container
         run: |
           REPO="$(echo "$GITHUB_REPOSITORY" | tr "[:upper:]" "[:lower:]")"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,6 +6,7 @@ on:
       - synchronize
       - reopened
     branches:
+      - develop
       - master
 
 concurrency:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/configuration/introduction.md
+++ b/configuration/introduction.md
@@ -9,6 +9,7 @@
 
 3. Minimum configuration requires the following:
 
+   <!-- prettier-ignore -->
    ```js
    let config = {
      modules: [
@@ -179,6 +180,7 @@ if (typeof module !== "undefined") {module.exports = config;}
 
 would be translated to
 
+<!-- prettier-ignore -->
 ```js
 let config = {
   address: "localhost",
@@ -186,9 +188,7 @@ let config = {
   useHttps: false,
 };
 /*************** DO NOT EDIT THE LINE BELOW ***************/
-if (typeof module !== "undefined") {
-  module.exports = config;
-}
+if (typeof module !== "undefined") {module.exports = config;}
 ```
 
 #### Defining variables


### PR DESCRIPTION
In the last PR, I noticed this repo wasn't running checks for PRs targeting `develop`. This PR enables those checks, updates the GitHub Actions versions, and adds a dependabot config.

With the dependabot config, dependency update PRs should target `develop` instead of `master` (as seen in #378).

Update:
The fourth commit was a fix for a formatting issue. The issue wouldn't have been noticed until the release - which would have been too late, because we don't really want to be dealing with formatting issues at the time of release. So this PR itself has become a good example of why it makes sense :)