### PR TITLE
update examples to use 'const' instead of 'let'

### DIFF
--- a/configuration/introduction.md
+++ b/configuration/introduction.md
@@ -11,7 +11,7 @@
 
    <!-- prettier-ignore -->
    ```js
-   let config = {
+   const config = {
      modules: [
        {
          module: "clock",
@@ -169,7 +169,7 @@ Variables must be inserted as `${MY_VARIABLE}`, examples:
 `config.js`:
 
 ```js
-let config = {
+const config = {
 	address: "${MY_ADDRESS}",
 	port: ${MY_PORT},
 	useHttps: ${MY_HTTPS},
@@ -182,7 +182,7 @@ would be translated to
 
 <!-- prettier-ignore -->
 ```js
-let config = {
+const config = {
   address: "localhost",
   port: 8080,
   useHttps: false,
@@ -233,7 +233,7 @@ You have two 1920x1080 monitors set up in the Pi as sitting next to each other:
 To move the pi to the second monitor, use this:
 
 ```js
-let config = {
+const config = {
 	electronOptions: { x: 1920 },
 	...
 ```
@@ -267,7 +267,7 @@ node --run start
 Configuration file 1 (config.js):
 
 ```js
-let config = {
+const config = {
 	address: "0.0.0.0", // Can be whatever you set as your original.
 	port: 8080, // Must be different than the other configuration file.
 	ipWhitelist: [], // Can be whatever you set as your original.
@@ -288,7 +288,7 @@ if (typeof module !== "undefined") {
 Configuration file 2 (config2.js):
 
 ```js
-let config = {
+const config = {
 	electronOptions: { x: 1920 },
 	address: "0.0.0.0", // can be whatever you set as your original.
 	port: 8081, // Must be different than the other configuration file.
@@ -317,7 +317,7 @@ them from the config.js file.
 `config.js`:
 
 ```js
-let config = {
+const config = {
   address: "0.0.0.0",
   port: 8080,
   ipWhitelist: [],

--- a/configuration/secrets.md
+++ b/configuration/secrets.md
@@ -54,7 +54,7 @@ including all secrets, and send it somewhere else.
 You have to add new parameters in `config.js`:
 
 ```js
-let config = {
+const config = {
   ...
   hideConfigSecrets: true,
   ...
@@ -73,7 +73,7 @@ In this example the 2 parameters are set with 2 normal environment variables
 `STRAVA_CLIENT_ID` and `STRAVA_API_KEY`:
 
 ```js
-let config = {
+const config = {
   ...
   hideConfigSecrets: true,
   ...
@@ -123,7 +123,7 @@ token in the URL.
 Example:
 
 ```js
-let config = {
+const config = {
   ...
   hideConfigSecrets: true,
   cors: "allowWhitelist",

--- a/core-development/debugging.md
+++ b/core-development/debugging.md
@@ -44,7 +44,7 @@ This mode monitors files specified in your `config.js` under the `watchTargets`
 property:
 
 ```js
-let config = {
+const config = {
   watchTargets: [
     "config/config.js",
     "config/custom.css",
@@ -91,7 +91,7 @@ Debug logging is disabled by default, and can be very verbose. It can be enabled
 in the _config/config.js_ file by adding `"DEBUG"` to the `logLevel` key:
 
 ```js
-let config = {
+const config = {
   // ...
   logLevel: ["INFO", "LOG", "WARN", "ERROR", "DEBUG"], // Add "DEBUG" for even more logging
   // ...

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -146,7 +146,7 @@ Sample Configuration below
 [and link to full configuration options](/configuration/introduction)
 
 ```js
-let config = {
+const config = {
 	address: "0.0.0.0",	// default is "localhost"
 	port: 8080,		// default
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1", "::ffff:172.17.0.1"], // default -- need to add your IP here

--- a/modules/configuration.md
+++ b/modules/configuration.md
@@ -20,7 +20,7 @@ see [configuration](/configuration/introduction) for more information.
 ## Example
 
 ```js
-let config = {
+const config = {
   modules: [
     {
       module: "clock",


### PR DESCRIPTION
I'm using `const` for a while now without issues.

This is a follow-up to https://github.com/MagicMirrorOrg/MagicMirror/pull/4196